### PR TITLE
PPC: Get the correct cache line size from the AUXV

### DIFF
--- a/src/cpu.h
+++ b/src/cpu.h
@@ -48,6 +48,7 @@ class CPU V8_FINAL BASE_EMBEDDED {
   static const int QUALCOMM = 0x51;
   int architecture() const { return architecture_; }
   int part() const { return part_; }
+  int cache_line_size() const { return cache_line_size_; }
 
   // ARM-specific part codes
   static const int ARM_CORTEX_A5 = 0xc05;
@@ -64,7 +65,8 @@ class CPU V8_FINAL BASE_EMBEDDED {
     PPC_POWER7,
     PPC_POWER8,
     PPC_G4,
-    PPC_G5
+    PPC_G5,
+    PPC_PA6T
   };
 
   // General features
@@ -103,6 +105,7 @@ class CPU V8_FINAL BASE_EMBEDDED {
   int implementer_;
   int architecture_;
   int part_;
+  int cache_line_size_;
   bool has_fpu_;
   bool has_cmov_;
   bool has_sahf_;

--- a/src/ppc/assembler-ppc.cc
+++ b/src/ppc/assembler-ppc.cc
@@ -74,6 +74,9 @@ void CpuFeatures::ProbeImpl(bool cross_compile) {
     // Assume support
     supported_ |= (1u << FPU);
   }
+  if (cpu.cache_line_size() != 0) {
+    cache_line_size_ = cpu.cache_line_size();
+  }
 #else
   // Fallback: assume frim is supported -- will implement processor
   // detection for other PPC platforms if required


### PR DESCRIPTION
Hi.  The cache line size for PPC is currently hard-coded at 128 bytes.  I'm on a PA6T system, with 64 byte cache lines, so that doesn't work out at all...  (A large amount of tests fail randomly when making check)

This patch finds the smallest non-zero cache line size specified in the AUXV and uses that instead of 128 whenever possible.  With it applied, I get about 1.5% fails from make ppc.release.check, so an immense improvement.  :-)
